### PR TITLE
Update Python to work under 2 and 3

### DIFF
--- a/python/goodbye-world.py
+++ b/python/goodbye-world.py
@@ -1,5 +1,6 @@
 #!/bin/env python
+from __future__ import print_function
 import sys
 
-print "Goodbye World"
+print("Goodbye World")
 sys.exit(0)


### PR DESCRIPTION
Imports a `print` function into older Pythons (2.6 & 2.7) to match Python 3.